### PR TITLE
Fix license file path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "GPL-2.0-or-later"
 version = "3.0.3"
 edition = "2024"
 publish = false
-license-file = "LICENSE.md"
+license-file = "LICENSE"
 
 [package.metadata.licenses]
 "tokio-serial" = { license = "MIT", source = "https://github.com/berkowski/tokio-serial", file = "examples/serial_println.rs" }


### PR DESCRIPTION
## Summary
- point Cargo manifest to the root LICENSE file

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687e940b35f8832a979012d204d0562a